### PR TITLE
Update setup.cfg + rv0.1.1c2

### DIFF
--- a/amadeusgpt/version.py
+++ b/amadeusgpt/version.py
@@ -6,5 +6,5 @@
 #
 # Licensed under Apache 2.0
 
-__version__ = "0.1.1rc1"
+__version__ = "0.1.1rc2"
 VERSION = __version__

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "AmadeusGPT"
 readme = "README.md"
 requires-python = ">=3.10"
 dynamic = ["version"]
-version = "0.1.1rc1"
+version = "0.1.1rc2"
 
 [tool.setuptools]
 packages = ["amadeusgpt"]

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = amadeusgpt
-version = 0.1.1rc1
+version = 0.1.1rc2
 author = Shaokai Ye, Jessy Lauer, Mu Zhou, Alexander Mathis, Mackenzie Mathis
 author_email = mackenzie@post.harvard.edu
 description = AmadeusGPT🎻: We turn natural language descriptions of behaviors into machine-executable code

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,9 +33,9 @@ install_requires =
     matplotlib<3.9
     ipympl
     PyYAML
-    tables==3.8
     streamlit>=1.26.0
     streamlit_drawable_canvas==0.9.2
+    #TONOTE: tables is required via conda install
 
 [options.extras_require]
 dev =


### PR DESCRIPTION
- tables 3.8 is not pip compatible (unfortunately), so for now users must install via conda... it is in the supplied conda file as well as in the main readme